### PR TITLE
Some better controls for versions of Python

### DIFF
--- a/.github/workflows/benchmark-impl.yml
+++ b/.github/workflows/benchmark-impl.yml
@@ -1,8 +1,5 @@
 name: ⚙️ Benchmark
 
-env:
-  POETRY_VERSION: "1.4"
-
 on:
   workflow_call: # This is a component workflow
     inputs:
@@ -37,6 +34,12 @@ on:
         required: true
         type: string
         description: The `github.ref` to benchmark.
+      poetry-version:
+        required: false
+        type: string
+        default: "1.4"
+        description: >
+          The version of Poetry to use.
     outputs:
       url:
         description: >
@@ -62,7 +65,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: benchmark

--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -1,9 +1,5 @@
 name: ⚙️ Build executables
 
-env:
-  PYTHON_VERSION_BUILD_EXES: "3.12"
-  POETRY_VERSION: "1.4"
-
 on:
   workflow_call: # This is a component workflow
     inputs:
@@ -49,6 +45,20 @@ on:
           Name of directory containing pyinstaller configuration, hooks and support files.
         required: true
         type: string
+      python-version:
+        description: >
+          Version of Python to use.
+          Note that the version in CentOS is locked by the Docker image.
+        type: string
+        required: false
+        default: "3.12"
+      poetry-version:
+        description: >
+          Version of Poetry to use.
+          Note that the version in CentOS is locked by the Docker image.
+        type: string
+        required: false
+        default: "1.4"
     outputs:
       linux-success:
         description: >
@@ -130,14 +140,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          python-version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: build-exe
-          version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -221,14 +231,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          python-version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: build-exe
-          version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -313,7 +323,7 @@ jobs:
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: build-exe
-          version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          version: ${{ inputs.python-version }}
 
       - name: Build executable (file) within Docker
         id: linux_onefile

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -1,13 +1,5 @@
 name: ⚙️ Release
 
-env:
-  PYTHON_VERSION_BUMP: "3.12"
-  PYTHON_VERSION_BUILD_EXES: "3.12"
-  PYTHON_VERSION_RELEASE: "3.12"
-  PYTHON_VERSION_BUILD_DOCS: "3.12"
-  PYTHON_VERSION_UPDATE_WEB: "3.12"
-  POETRY_VERSION: "1.4"
-
 on:
   workflow_call:
     inputs:
@@ -113,6 +105,20 @@ on:
         description: >
           Attribute: `github.event.pull_request.head.ref`
           Where was the PR merged from?
+      python-version:
+        description: >
+          Version of Python to use.
+          Note that the version in CentOS is locked by the Docker image.
+        type: string
+        required: false
+        default: "3.12"
+      poetry-version:
+        description: >
+          Version of Poetry to use.
+          Note that the version in CentOS is locked by the Docker image.
+        type: string
+        required: false
+        default: "1.4"
     secrets:
       general-token:
         description: >
@@ -166,7 +172,7 @@ jobs:
       - uses: hpcflow/github-support/configure-git@0.1
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_BUMP }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Get git-chglog executable
         run: |
@@ -299,14 +305,14 @@ jobs:
           ref: ${{ inputs.pr-base-ref }} # otherwise we get the ref when the workflow started (missing above commit)
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          python-version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: build
-          version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: poetry install --without dev
@@ -391,7 +397,7 @@ jobs:
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: build
-          version: ${{ env.PYTHON_VERSION_BUILD_EXES }}
+          version: ${{ inputs.python-version }}
 
       - name: Build executables within Docker
         uses: addnab/docker-run-action@v3
@@ -478,7 +484,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: benchmark
@@ -540,14 +546,14 @@ jobs:
           ref: ${{ inputs.pr-base-ref }} # otherwise we get the ref when the workflow started (missing above commit)
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_RELEASE }}
+          python-version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: release
-          version: ${{ env.PYTHON_VERSION_RELEASE }}
+          version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: poetry install --without dev,pyinstaller
@@ -622,7 +628,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_BUILD_DOCS }}
+          python-version: ${{ inputs.python-version }}
 
       - name: Write binary links YAML file and push
         run: |
@@ -649,10 +655,10 @@ jobs:
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: release-doc
-          version: ${{ env.PYTHON_VERSION_BUILD_DOCS }}
+          version: ${{ inputs.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: poetry install --without test,pyinstaller
@@ -677,7 +683,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_UPDATE_WEB }}
+          python-version: ${{ inputs.python-version }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -90,6 +90,16 @@ on:
         type: string
         description: Which github-support branch to fetch support scripts from.
         default: main
+      python-versions:
+        required: false
+        type: string
+        description: The JSON array of Python versions to test with.
+        default: '["3.9", "3.10", "3.11", "3.12"]'
+      poetry-version:
+        required: false
+        type: string
+        description: Version of Poetry.
+        default: "1.4"
     secrets:
       pre-commit-token:
         required: true
@@ -99,10 +109,6 @@ on:
   
 # e.g. don't run simultaneously on the same branch (since we may commit to that branch)
 concurrency: ci-${{ inputs.head-ref && format('refs/heads/{0}', inputs.head-ref) || inputs.ref }}
-
-env:
-  PYTHON_VERSION_PRE_COMMIT: "3.12"
-  POETRY_VERSION: "1.4"
 
 jobs:
   pre-commit:
@@ -122,7 +128,7 @@ jobs:
       - uses: hpcflow/github-support/configure-git@0.1
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ env.PYTHON_VERSION_PRE_COMMIT }}
+          python-version: "3.12"
 
       - name: pre-commit
         # avoid exit code 1 (which halts GH actions) from pre-commit run command by
@@ -148,11 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
         os:
           - ubuntu-latest
           - macos-13
@@ -166,9 +168,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@0.1
+      - uses: hpcflow/github-support/setup-poetry@main
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: test
@@ -215,11 +217,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
         os:
           - ubuntu-latest
           - macos-13
@@ -233,9 +231,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@0.1
+      - uses: hpcflow/github-support/setup-poetry@main
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: test-integration
@@ -282,11 +280,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -299,10 +293,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@0.1
-        id: python
+      - uses: hpcflow/github-support/setup-poetry@main
+        id: poetry
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: test-invocation
@@ -317,62 +311,63 @@ jobs:
         id: prep-test-data
         run: |
           echo "exe-path=${PY//python/$EXE_NAME}" >> $GITHUB_OUTPUT
+          mkdir papermill_out
         env:
           EXE_NAME: ${{ inputs.executable_name }}
-          PY: ${{ steps.python.outputs.python-path }}
+          PY: ${{ steps.poetry.outputs.python-path }}
 
       - name: Test invocation command with `python ./${{ inputs.CLI_path }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python ./${{ inputs.CLI_path }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with `python -m ${{ inputs.CLI_module }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python -m ${{ inputs.CLI_module }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with `${{ inputs.executable_name }}` entry point script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: ${{ inputs.executable_name }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ steps.prep-test-data.outputs.exe-path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ steps.prep-test-data.outputs.exe-path }}')"
 
       - name: Test invocation command within a python script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd.py ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with interactive python
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd_interactive.py python ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with interactive ipython
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd_interactive.py ipython ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test direct workflow submission within a python script
         run: |
-          source $(poetry env info --path)/bin/activate
+          source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           python github-support/scripts/test_direct_sub_python_script.py ${{ inputs.app_package }}
 
       - name: Test direct workflow submission within a Jupyter notebook (via papermill)
         run: |
-          source $(poetry env info --path)/bin/activate
+          source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           python -m ipykernel install --user --name python3
-          papermill github-support/scripts/test_direct_sub_jupyter_notebook.ipynb github-support/scripts/test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
+          papermill github-support/scripts/test_direct_sub_jupyter_notebook.ipynb papermill_out/test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
 
   test-invocation-macos:
     if: inputs.invocation_tests == 'true'
@@ -380,11 +375,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -397,10 +388,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@0.1
-        id: python
+      - uses: hpcflow/github-support/setup-poetry@main
+        id: poetry
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: test-invocation
@@ -415,62 +406,63 @@ jobs:
         id: prep-test-data
         run: |
           echo "exe-path=${PY//python/$EXE_NAME}" >> $GITHUB_OUTPUT
+          mkdir papermill_out
         env:
           EXE_NAME: ${{ inputs.executable_name }}
-          PY: ${{ steps.python.outputs.python-path }}
+          PY: ${{ steps.poetry.outputs.python-path }}
 
       - name: Test invocation command with `python ./${{ inputs.CLI_path }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python ./${{ inputs.CLI_path }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with `python -m ${{ inputs.CLI_module }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python -m ${{ inputs.CLI_module }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with `${{ inputs.executable_name }}` entry point script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: ${{ inputs.executable_name }} internal get-invoc-cmd
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ steps.prep-test-data.outputs.exe-path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ steps.prep-test-data.outputs.exe-path }}')"
 
       - name: Test invocation command within a python script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd.py ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with interactive python
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd_interactive.py python ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test invocation command with interactive ipython
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: source $(poetry env info --path)/bin/activate
+          init: source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           command: python github-support/scripts/get_invoc_cmd_interactive.py ipython ${{ inputs.app_package }}
-          expected: "('${{ steps.python.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
+          expected: "('${{ steps.poetry.outputs.python-path }}', '${{ github.workspace }}/${{ inputs.CLI_path }}')"
 
       - name: Test direct workflow submission within a python script
         run: |
-          source $(poetry env info --path)/bin/activate
+          source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           python github-support/scripts/test_direct_sub_python_script.py ${{ inputs.app_package }}
 
       - name: Test direct workflow submission within a Jupyter notebook (via papermill)
         run: |
-          source $(poetry env info --path)/bin/activate
+          source ${{ steps.poetry.outputs.poetry-path }}/bin/activate
           python -m ipykernel install --user --name python3
-          papermill github-support/scripts/test_direct_sub_jupyter_notebook.ipynb github-support/scripts/test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
+          papermill github-support/scripts/test_direct_sub_jupyter_notebook.ipynb papermill_out/test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
 
   test-invocation-windows:
     if: inputs.invocation_tests == 'true'
@@ -478,11 +470,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -495,10 +483,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@0.1
+      - uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         with:
-          version: ${{ env.POETRY_VERSION }}
+          version: ${{ inputs.poetry-version }}
       - uses: hpcflow/github-support/init-cache@0.1
         with:
           name: test-invocation
@@ -514,6 +502,7 @@ jobs:
           ("python-path=" + $Env:PY.Replace('\', '\\')) | Out-File $Env:GITHUB_OUTPUT -Append
           ("cli-path=$Env:GITHUB_WORKSPACE\$Env:CLI_PATH".Replace('\', '\\')) | Out-File $Env:GITHUB_OUTPUT -Append
           ("exe-path=$Env:PY".Replace('python.exe', $Env:EXE_NAME).Replace('\', '\\')) | Out-File $Env:GITHUB_OUTPUT -Append
+          New-Item -ItemType Directory -Path papermill_out
         env:
           CLI_PATH: ${{ inputs.CLI_path_win }}
           EXE_NAME: ${{ inputs.executable_name }}
@@ -522,38 +511,38 @@ jobs:
       - name: Test invocation command with `python ./${{ inputs.CLI_path }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: ."$(poetry env info --path)\Scripts\activate.ps1"
+          init: ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           command: python ./${{ inputs.CLI_path }} internal get-invoc-cmd
           expected: "('${{ steps.prep-test-data.outputs.python-path }}', '${{ steps.prep-test-data.outputs.cli-path }}')"
 
       - name: Test invocation command with `python -m ${{ inputs.CLI_module }}`
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: ."$(poetry env info --path)\Scripts\activate.ps1"
+          init: ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           command: python -m ${{ inputs.CLI_module }} internal get-invoc-cmd
           expected: "('${{ steps.prep-test-data.outputs.python-path }}', '${{ steps.prep-test-data.outputs.cli-path }}')"
 
       - name: Test invocation command with `${{ inputs.executable_name }}` entry point script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: ."$(poetry env info --path)\Scripts\activate.ps1"
+          init: ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           command: ${{ inputs.executable_name }} internal get-invoc-cmd
           expected: "('${{ steps.prep-test-data.outputs.python-path }}', '${{ steps.prep-test-data.outputs.exe-path }}')"
 
       - name: Test invocation command within a python script
         uses: hpcflow/github-support/compare@0.1
         with:
-          init: ."$(poetry env info --path)\Scripts\activate.ps1"
+          init: ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           command: python github-support\scripts\get_invoc_cmd.py ${{ inputs.app_package }}
           expected: "('${{ steps.prep-test-data.outputs.python-path }}', '${{ steps.prep-test-data.outputs.cli-path }}')"
 
       - name: Test direct workflow submission within a python script
         run: |
-          ."$(poetry env info --path)\Scripts\activate.ps1"
+          ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           python github-support\scripts\test_direct_sub_python_script.py ${{ inputs.app_package }}
 
       - name: Test direct workflow submission within a Jupyter notebook (via papermill)
         run: |
-          ."$(poetry env info --path)\Scripts\activate.ps1"
+          ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           python -m ipykernel install --user --name python3
-          papermill github-support\scripts\test_direct_sub_jupyter_notebook.ipynb github-support\scripts\test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
+          papermill github-support\scripts\test_direct_sub_jupyter_notebook.ipynb papermill_out\test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}

--- a/.github/workflows/test-pre-python-impl.yml
+++ b/.github/workflows/test-pre-python-impl.yml
@@ -18,7 +18,17 @@ on:
           Extra arguments to pass to pytest.
         required: true
         type: string
-
+      python-versions:
+        required: false
+        type: string
+        description: The JSON array of Python versions to test with.
+        default: '["3.13-dev"]'
+      poetry-version:
+        required: false
+        type: string
+        description: Version of Poetry.
+        default: "1.4"
+  
 # Don't run simultaneously on the same branch (since we may commit to that branch)
 concurrency: ci-${{ inputs.head-ref && format('refs/heads/{0}', inputs.head-ref) || inputs.ref }}
 
@@ -27,8 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - "3.13-dev"
+        python-version: ${{ fromJSON(inputs.python-versions) }}
         os:
           - ubuntu-latest
           - macos-13
@@ -49,7 +58,7 @@ jobs:
           version: ${{ matrix.python-version }}
       - uses: hpcflow/github-support/setup-poetry@0.1
         with:
-          version: 1.4
+          version: ${{ inputs.poetry-version }}
 
       - name: Install dependencies
         run: |

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -19,7 +19,9 @@ runs:
         python -m pip install poetry==$VERSION
         poetry config virtualenvs.in-project true
         poetry config installer.modern-installation false
+        POETRY_PATH=$(poetry env info --path)
         echo "python=${GITHUB_WORKSPACE}${SEP}.venv${SEP}${LOC}${SEP}python${SUFFIX}" >> $GITHUB_OUTPUT
+        echo "poetry-path=$(POETRY_PATH)" >> $GITHUB_OUTPUT
       env:
         VERSION: ${{ inputs.version }}
         SEP: ${{ runner.os == 'Windows' && '\' || '/' }}


### PR DESCRIPTION
Moves versions of Python and Poetry into workflow inputs. (So we'll be able to enable for Python 3.13 and deprecate 3.9 without updating these workflows.)

Also factors out the discovery of the Poetry environment path because it was very commonly used in the test workflow.