### PR TITLE
Enable tracking of updates to actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot is a software robot for checking that dependencies are up to date.

Doesn't support Poetry yet (dependabot/dependabot-core#8603), so not yet very useful for hpcflow and matflow. When enabled for that, setting up _upper_ bounds on versions may become important. But here we're just using it for Github Actions which are typically not so much of a pain. 