### PR TITLE
Fix failure in release workflow

### DIFF
--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -16,6 +16,10 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Upgrade pip
+      shell: bash
+      run: |
+        python -m pip install -U pip setuptools wheel
     - name: Install
       shell: bash
       run: |

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       run: |
         python -m pip install -U pip setuptools wheel
+        echo PIP_DISABLE_PIP_VERSION_CHECK=1 >> $GITHUB_ENV
     - name: Install
       shell: bash
       run: |


### PR DESCRIPTION
This adds a step to the setup-poetry action to upgrade pip because otherwise things fail annoyingly.