### PR TITLE
Disable output buffering when running tests

### DIFF
--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -208,6 +208,7 @@ jobs:
         if: steps.win_onefile.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win.exe test ${{ inputs.unit_test_args }}
 
@@ -215,6 +216,7 @@ jobs:
         if: steps.win_onedir.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win-dir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win-dir.exe test ${{ inputs.unit_test_args }}
 
@@ -299,6 +301,7 @@ jobs:
         if: steps.mac_onefile.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS test ${{ inputs.unit_test_args }}
 
@@ -306,6 +309,7 @@ jobs:
         if: steps.mac_onedir.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir test ${{ inputs.unit_test_args }}
 
@@ -347,6 +351,7 @@ jobs:
             # set demo data GitHub URL using current git SHA (file), instead of default which is current version tag
             ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux config set-github-demo-data-dir ${{ needs.status.outputs.sha }}
 
+            export PYTHONUNBUFFERED=ok
             # run test suite on the frozen app (file)
             ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux test ${{ inputs.unit_test_args }}
 
@@ -372,6 +377,7 @@ jobs:
             # set demo data GitHub URL using current git SHA (folder), instead of default which is current version tag
             ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir config set-github-demo-data-dir ${{ needs.status.outputs.sha }}
 
+            export PYTHONUNBUFFERED=ok
             # run test suite on the frozen app (folder)
             ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir test ${{ inputs.unit_test_args }}
 

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -119,7 +119,7 @@ on:
         required: false
         type: number
         description: Time to allow for a workflow to run integration tests.
-        default: 5
+        default: 25
     secrets:
       pre-commit-token:
         required: true

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -185,6 +185,7 @@ jobs:
       - name: Run tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           poetry run python -m pytest ${{ inputs.pytest_args }} ${{ inputs.unit_test_args }}
 
@@ -214,6 +215,7 @@ jobs:
             poetry config virtualenvs.in-project true
             poetry config installer.modern-installation false
             poetry install --without dev,pyinstaller
+            export PYTHONUNBUFFERED=ok
             poetry run python -m pytest ${{ inputs.unit_test_args }}
 
   test-integration:
@@ -250,9 +252,10 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
 
-      - name: Run tests
+      - name: Run integration tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: ok
         run: |
           poetry run ${{ inputs.executable_name }} test ${{ inputs.pytest_args }} --integration ${{ inputs.integration_test_args }}
 
@@ -282,6 +285,7 @@ jobs:
             poetry config virtualenvs.in-project true
             poetry config installer.modern-installation false
             poetry install --without dev,pyinstaller
+            export PYTHONUNBUFFERED=ok
             poetry run ${{ inputs.executable_name }} test --integration ${{ inputs.integration_test_args }}
 
   test-invocation-ubuntu:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -118,19 +118,23 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     if: inputs.pre_commit == 'true'
+    timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.pre-commit-token }}
           # checkout PR source branch (head_ref) if event is pull_request:
           ref: ${{ inputs.head-ref || inputs.ref }}
           repository: ${{ inputs.full-repo-name }}
-      - uses: hpcflow/github-support/configure-git@main
-      - uses: actions/setup-python@v5
+      - name: Configure git for commits
+        uses: hpcflow/github-support/configure-git@main
+      - name: Set up python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: pre-commit
+      - name: Run pre-commit
         # avoid exit code 1 (which halts GH actions) from pre-commit run command by
         # running twice:
         run: |
@@ -164,25 +168,32 @@ jobs:
       contents: read
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v5
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@main
+      - name: Set up poetry
+        uses: hpcflow/github-support/setup-poetry@main
+        timeout-minutes: 5
         with:
           version: ${{ inputs.poetry-version }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test
           version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: |
           poetry install --without dev,pyinstaller
 
       - name: Run tests
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: ok
@@ -197,10 +208,12 @@ jobs:
       # No write permission
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test
           version: CentOS
@@ -217,6 +230,7 @@ jobs:
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run python -m pytest ${{ inputs.unit_test_args }}
+        timeout-minutes: 5
 
   test-integration:
     needs: pre-commit
@@ -234,25 +248,31 @@ jobs:
       contents: read
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v5
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@main
+      - name: Set up poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test-integration
           version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: |
           poetry install --without dev,pyinstaller
 
       - name: Run integration tests
+        timeout-minutes: 25
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: ok
@@ -267,10 +287,12 @@ jobs:
       # No write permission
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test-integration
           version: CentOS
@@ -287,6 +309,7 @@ jobs:
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run ${{ inputs.executable_name }} test --integration ${{ inputs.integration_test_args }}
+        timeout-minutes: 25
 
   test-invocation-ubuntu:
     if: inputs.invocation_tests == 'true'
@@ -299,22 +322,27 @@ jobs:
       # No write permission
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/checkout@v4
+      - name: Checkout supporting test infrastructure
+        uses: actions/checkout@v4
         with:
           repository: hpcflow/github-support
           path: github-support
           ref: ${{ inputs.script-branch }}
-      - uses: actions/setup-python@v5
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@main
+      - name: Set up poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         with:
           version: ${{ inputs.poetry-version }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test-invocation
           version: ${{ matrix.python-version }}
@@ -323,6 +351,7 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
           poetry run pip install ipython
+        timeout-minutes: 5
 
       - name: Prepare test data
         id: prep-test-data
@@ -397,22 +426,27 @@ jobs:
       # No write permission
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/checkout@v4
+      - name: Checkout supporting test infrastructure
+        uses: actions/checkout@v4
         with:
           repository: hpcflow/github-support
           path: github-support
           ref: ${{ inputs.script-branch }}
-      - uses: actions/setup-python@v5
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@main
+      - name: Set up poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         with:
           version: ${{ inputs.poetry-version }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test-invocation
           version: ${{ matrix.python-version }}
@@ -421,6 +455,7 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
           poetry run pip install ipython
+        timeout-minutes: 5
 
       - name: Prepare test data
         id: prep-test-data
@@ -495,22 +530,27 @@ jobs:
       # No write permission
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/checkout@v4
+      - name: Checkout supporting test infrastructure
+        uses: actions/checkout@v4
         with:
           repository: hpcflow/github-support
           path: github-support
           ref: ${{ inputs.script-branch }}
-      - uses: actions/setup-python@v5
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hpcflow/github-support/setup-poetry@main
+      - name: Set up poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         with:
           version: ${{ inputs.poetry-version }}
-      - uses: hpcflow/github-support/init-cache@main
+      - name: Cache dependencies
+        uses: hpcflow/github-support/init-cache@main
         with:
           name: test-invocation
           version: ${{ matrix.python-version }}
@@ -518,6 +558,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --without dev,pyinstaller
+        timeout-minutes: 5
 
       - name: Prepare test data
         id: prep-test-data

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -100,6 +100,26 @@ on:
         type: string
         description: Version of Poetry.
         default: "1.4"
+      install-timeout-minutes:
+        required: false
+        type: number
+        description: Time to allow for a workflow to install dependencies.
+        default: 5
+      install-poetry-timeout-minutes:
+        required: false
+        type: number
+        description: Time to allow for a workflow to install poetry.
+        default: 5
+      unit-test-timeout-minutes:
+        required: false
+        type: number
+        description: Time to allow for a workflow to run unit tests.
+        default: 5
+      integration-test-timeout-minutes:
+        required: false
+        type: number
+        description: Time to allow for a workflow to run integration tests.
+        default: 5
     secrets:
       pre-commit-token:
         required: true
@@ -178,7 +198,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
         uses: hpcflow/github-support/setup-poetry@main
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -188,12 +208,12 @@ jobs:
           version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-timeout-minutes }}
         run: |
           poetry install --without dev,pyinstaller
 
       - name: Run tests
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.unit-test-timeout-minutes }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: ok
@@ -230,7 +250,7 @@ jobs:
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run python -m pytest ${{ inputs.unit_test_args }}
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.unit-test-timeout-minutes }}
 
   test-integration:
     needs: pre-commit
@@ -258,6 +278,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
         uses: hpcflow/github-support/setup-poetry@main
+        timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -267,12 +288,12 @@ jobs:
           version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-timeout-minutes }}
         run: |
           poetry install --without dev,pyinstaller
 
       - name: Run integration tests
-        timeout-minutes: 25
+        timeout-minutes: ${{ inputs.integration-test-timeout-minutes }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: ok
@@ -309,7 +330,7 @@ jobs:
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run ${{ inputs.executable_name }} test --integration ${{ inputs.integration_test_args }}
-        timeout-minutes: 25
+        timeout-minutes: ${{ inputs.integration-test-timeout-minutes }}
 
   test-invocation-ubuntu:
     if: inputs.invocation_tests == 'true'
@@ -339,6 +360,7 @@ jobs:
       - name: Set up poetry
         uses: hpcflow/github-support/setup-poetry@main
         id: poetry
+        timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -351,7 +373,7 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
           poetry run pip install ipython
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-timeout-minutes }}
 
       - name: Prepare test data
         id: prep-test-data
@@ -443,6 +465,7 @@ jobs:
       - name: Set up poetry
         uses: hpcflow/github-support/setup-poetry@main
         id: poetry
+        timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -455,7 +478,7 @@ jobs:
         run: |
           poetry install --without dev,pyinstaller
           poetry run pip install ipython
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-timeout-minutes }}
 
       - name: Prepare test data
         id: prep-test-data
@@ -547,6 +570,7 @@ jobs:
       - name: Set up poetry
         uses: hpcflow/github-support/setup-poetry@main
         id: poetry
+        timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -558,7 +582,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --without dev,pyinstaller
-        timeout-minutes: 5
+        timeout-minutes: ${{ inputs.install-timeout-minutes }}
 
       - name: Prepare test data
         id: prep-test-data

--- a/.github/workflows/test-pre-python-impl.yml
+++ b/.github/workflows/test-pre-python-impl.yml
@@ -67,3 +67,5 @@ jobs:
       - name: Run tests
         run: |
           poetry run python -m pytest ${{ inputs.pytest-args }}
+        env:
+          PYTHONUNBUFFERED: ok


### PR DESCRIPTION
This makes the tests look less like they're hanging if they're just taking their sweet time instead. More of an issue with the integration tests, but relevant for all.