### PR TITLE
Try to fix release triggering on non-merged PRs

### DIFF
--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -157,7 +157,7 @@ on:
 jobs:
   bump-version:
     # skip if trying to re-run; PR is closed without merging; '[skip release]' is in the PR title; or if merging any branch other than pre_release_branch into release_branch
-    if: inputs.gh-run-attempt == '1' && inputs.pr-merged && !contains(inputs.pr-title, '[skip release]') && (inputs.pr-base-ref == inputs.pre_release_branch || (inputs.pr-base-ref == inputs.release_branch && inputs.pr-head-ref == inputs.pre_release_branch))
+    if: inputs.gh-run-attempt == '1' && inputs.pr-merged == true && !contains(inputs.pr-title, '[skip release]') && (inputs.pr-base-ref == inputs.pre_release_branch || (inputs.pr-base-ref == inputs.release_branch && inputs.pr-head-ref == inputs.pre_release_branch))
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.new_tag.outputs.tag }}


### PR DESCRIPTION
According to the example here https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges we should  be explicit with the `merged` check: `github.event.pull_request.merged == true`.

For the relevant input parametrisation in hpcflow-new see: https://github.com/hpcflow/hpcflow-new/blob/b9300f0dd330ec11049f77a4093b54d93d3e4836/.github/workflows/release.yml#L14C22-L14C54.

Hopefully this will fix #16.