### PR TITLE
fix: release workflow always skipping

### DIFF
--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -157,7 +157,7 @@ on:
 jobs:
   bump-version:
     # skip if trying to re-run; PR is closed without merging; '[skip release]' is in the PR title; or if merging any branch other than pre_release_branch into release_branch
-    if: inputs.gh-run-attempt == '1' && inputs.pr-merged == true && !contains(inputs.pr-title, '[skip release]') && (inputs.pr-base-ref == inputs.pre_release_branch || (inputs.pr-base-ref == inputs.release_branch && inputs.pr-head-ref == inputs.pre_release_branch))
+    if: inputs.gh-run-attempt == '1' && inputs.pr-merged == 'true' && !contains(inputs.pr-title, '[skip release]') && (inputs.pr-base-ref == inputs.pre_release_branch || (inputs.pr-base-ref == inputs.release_branch && inputs.pr-head-ref == inputs.pre_release_branch))
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.new_tag.outputs.tag }}


### PR DESCRIPTION
The workflow input `pr-merged` has type `string` (https://github.com/hpcflow/github-support/blob/20de144d00a88c9fb64d29013cbb7f30d7f1c0f1/.github/workflows/release-impl.yml#L84), so hopefully this will resolve the issue.