### PR TITLE
Change old-GLIBC Docker image to Rocky Linux 8

### DIFF
--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -48,21 +48,21 @@ on:
       python-version:
         description: >
           Version of Python to use.
-          Note that the version in CentOS is locked by the Docker image.
+          Note that the version in Rocky Linux is locked by the Docker image.
         type: string
         required: false
         default: "3.12"
       poetry-version:
         description: >
           Version of Poetry to use.
-          Note that the version in CentOS is locked by the Docker image.
+          Note that the version in Rocky Linux is locked by the Docker image.
         type: string
         required: false
         default: "1.4"
     outputs:
       linux-success:
         description: >
-          Whether we built at least one executable format for CentOS Linux.
+          Whether we built at least one executable format for Rocky Linux.
         value: ${{ jobs.linux.outputs.success }}
       macos-success:
         description: >
@@ -74,12 +74,12 @@ on:
         value: ${{ jobs.windows.outputs.success }}
       linux-file-url:
         description: >
-          Where to download the single-file build for CentOS Linux.
+          Where to download the single-file build for Rocky Linux.
           This is a temporary URL with access controls applied.
         value: ${{ jobs.linux.outputs.file }}
       linux-folder-url:
         description: >
-          Where to download the folder-based build for CentOS Linux.
+          Where to download the folder-based build for Rocky Linux.
           This is a temporary URL with access controls applied.
         value: ${{ jobs.linux.outputs.folder }}
       macos-file-url:
@@ -102,7 +102,7 @@ on:
           Where to download the folder-based build for Windows.
           This is a temporary URL with access controls applied.
         value: ${{ jobs.windows.outputs.folder }}
-            
+
 jobs:
   status:
     name: Get Git Information
@@ -323,7 +323,7 @@ jobs:
           ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir test ${{ inputs.unit_test_args }}
 
   linux:
-    name: Build Linux (CentOS 7) Executables
+    name: Build Linux (Rocky Linux 8) Executables
     if: inputs.build_linux == 'true'
     outputs:
       success: ${{ steps.upload-file.outcome == 'success' || steps.upload-folder.outcome == 'success' }}
@@ -345,16 +345,15 @@ jobs:
         if: inputs.build_onefile == 'true'
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/hpcflow/centos7-poetry:latest
+          image: ghcr.io/hpcflow/rockylinux8-python:latest
           options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             # set up poetry
             cd /home
             poetry config virtualenvs.in-project true
-            poetry config installer.modern-installation false
             poetry install --without dev
 
-            # build with pyinstaller for CentOS (file)
+            # build with pyinstaller for Rocky Linux (file)
             cd ${{ inputs.pyinstaller_dir }}
             ./make.sh ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux ${{ inputs.logLevel }} onefile
             cd ..
@@ -371,16 +370,15 @@ jobs:
         if: inputs.build_onedir == 'true'
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/hpcflow/centos7-poetry:latest
+          image: ghcr.io/hpcflow/rockylinux8-python:latest
           options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             # set up poetry
             cd /home
             poetry config virtualenvs.in-project true
-            poetry config installer.modern-installation false
             poetry install --without dev
 
-            # build with pyinstaller for CentOS (folder)
+            # build with pyinstaller for Rocky Linux (folder)
             cd ${{ inputs.pyinstaller_dir }}
             ./make.sh ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir ${{ inputs.logLevel }} onedir
             cd ..

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -38,7 +38,7 @@ on:
         type: string
         description: >
           Template parameter.
-          Path to Python file containing application version data. 
+          Path to Python file containing application version data.
       benchmark_make_workflow:
         required: true
         type: string
@@ -108,14 +108,14 @@ on:
       python-version:
         description: >
           Version of Python to use.
-          Note that the version in CentOS is locked by the Docker image.
+          Note that the version in Rocky Linux is locked by the Docker image.
         type: string
         required: false
         default: "3.12"
       poetry-version:
         description: >
           Version of Poetry to use.
-          Note that the version in CentOS is locked by the Docker image.
+          Note that the version in Rocky Linux is locked by the Docker image.
         type: string
         required: false
         default: "1.4"
@@ -153,7 +153,7 @@ on:
         description: >
           Whether the release was successfully published to the website.
         value: ${{ jobs.update-website.outputs.publish-state == 'success' }}
-  
+
 jobs:
   bump-version:
     # skip if trying to re-run; PR is closed without merging; '[skip release]' is in the PR title; or if merging any branch other than pre_release_branch into release_branch
@@ -412,18 +412,17 @@ jobs:
       - name: Build executables within Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/hpcflow/centos7-poetry:latest
+          image: ghcr.io/hpcflow/rockylinux8-python:latest
           options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.general-token }}
           run: |
             # set up poetry
             cd /home
             poetry config virtualenvs.in-project true
-            poetry config installer.modern-installation false
             poetry install --without dev
             base="${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}"
             vers_expected="${{ inputs.app_name }}, version ${{ needs.bump-version.outputs.version }}"
 
-            # build with pyinstaller for CentOS (file)
+            # build with pyinstaller for Rocky Linux (file)
             cd ${{ inputs.pyinstaller_dir }}
             ./make.sh ${base}-linux INFO onefile
             cd ..
@@ -437,7 +436,7 @@ jobs:
             # run test suite on the frozen app (file)
             ${{ inputs.pyinstaller_dir }}/dist/onefile/${base}-linux test
 
-            # build with pyinstaller for CentOS (folder)
+            # build with pyinstaller for Rocky Linux (folder)
             cd ${{ inputs.pyinstaller_dir }}
             ./make.sh ${base}-linux-dir INFO onedir
             cd ..

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       invocation_tests:
-        description: > 
+        description: >
           Run invocation tests.
         required: true
         type: string
@@ -131,7 +131,7 @@ on:
         description: >
           PAT of user who has permission to bypass branch protection,
           or standard GITHUB_TOKEN if running on an external fork
-  
+
 # e.g. don't run simultaneously on the same branch (since we may commit to that branch)
 concurrency: ci-${{ inputs.head-ref && format('refs/heads/{0}', inputs.head-ref) || inputs.ref }}
 
@@ -225,7 +225,7 @@ jobs:
         run: |
           poetry run python -m pytest ${{ inputs.pytest_args }} ${{ inputs.unit_test_args }}
 
-  test-units-CentOS:
+  test-units-RockyLinux:
     needs: pre-commit
     runs-on: ubuntu-latest
     if: inputs.unit_tests == 'true'
@@ -241,17 +241,16 @@ jobs:
         uses: hpcflow/github-support/init-cache@main
         with:
           name: test
-          version: CentOS
+          version: RockyLinux
 
       - name: Run unit tests within Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/hpcflow/centos7-poetry:latest
+          image: ghcr.io/hpcflow/rockylinux8-python:latest
           options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             cd /home
             poetry config virtualenvs.in-project true
-            poetry config installer.modern-installation false
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run python -m pytest ${{ inputs.unit_test_args }}
@@ -305,7 +304,7 @@ jobs:
         run: |
           poetry run ${{ inputs.executable_name }} test ${{ inputs.pytest_args }} --integration ${{ inputs.integration_test_args }}
 
-  test-integration-CentOS:
+  test-integration-RockyLinux:
     needs: pre-commit
     runs-on: ubuntu-latest
     if: inputs.integration_tests == 'true'
@@ -321,17 +320,16 @@ jobs:
         uses: hpcflow/github-support/init-cache@main
         with:
           name: test-integration
-          version: CentOS
+          version: RockyLinux
 
       - name: Run integration tests within Docker
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/hpcflow/centos7-poetry:latest
+          image: ghcr.io/hpcflow/rockylinux8-python:latest
           options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             cd /home
             poetry config virtualenvs.in-project true
-            poetry config installer.modern-installation false
             poetry install --without dev,pyinstaller
             export PYTHONUNBUFFERED=ok
             poetry run ${{ inputs.executable_name }} test --integration ${{ inputs.integration_test_args }}


### PR DESCRIPTION
Will fix: https://github.com/hpcflow/hpcflow-new/issues/853

I've tested the build-executables and test workflows in the hpcflow `rockylinux` branch here: 
- https://github.com/hpcflow/hpcflow-new/actions/runs/16303998548/job/46045520023
- https://github.com/hpcflow/hpcflow-new/actions/runs/16304370768/job/46046822893

Unrelated failures:
- the Windows build-executables failure is unrelated (https://github.com/hpcflow/hpcflow-new/issues/854)
- I discovered som integration tests run via the built executables also fail, but this is also unrelated (https://github.com/hpcflow/hpcflow-new/issues/855)

Note: the `rockylinux` branch in `hpcflow-new` can be deleted after this PR is merged.