### PR TITLE
Update poetry to current version

### DIFF
--- a/.github/workflows/benchmark-impl.yml
+++ b/.github/workflows/benchmark-impl.yml
@@ -37,7 +37,7 @@ on:
       poetry-version:
         required: false
         type: string
-        default: "1.4"
+        default: "2.1.3"
         description: >
           The version of Poetry to use.
     outputs:
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies

--- a/.github/workflows/benchmark-impl.yml
+++ b/.github/workflows/benchmark-impl.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies

--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -58,7 +58,7 @@ on:
           Note that the version in CentOS is locked by the Docker image.
         type: string
         required: false
-        default: "1.4"
+        default: "2.1.3"
     outputs:
       linux-success:
         description: >
@@ -102,7 +102,7 @@ on:
           Where to download the folder-based build for Windows.
           This is a temporary URL with access controls applied.
         value: ${{ jobs.windows.outputs.folder }}
-            
+
 jobs:
   status:
     name: Get Git Information

--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -150,7 +150,7 @@ jobs:
           name: build-exe
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -247,7 +247,7 @@ jobs:
           name: build-exe
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -150,7 +150,7 @@ jobs:
           name: build-exe
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -247,7 +247,7 @@ jobs:
           name: build-exe
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/.github/workflows/doc-build-impl.yml
+++ b/.github/workflows/doc-build-impl.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install and configure poetry ${{ inputs.poetry-version }}
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache Virtual Environment

--- a/.github/workflows/doc-build-impl.yml
+++ b/.github/workflows/doc-build-impl.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install and configure poetry ${{ inputs.poetry-version }}
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache Virtual Environment

--- a/.github/workflows/doc-build-impl.yml
+++ b/.github/workflows/doc-build-impl.yml
@@ -12,7 +12,7 @@ on:
         description: Version of Poetry to use to manage dependencies.
         required: false
         type: string
-        default: "1.4"
+        default: "2.1.3"
       script-branch:
         description: Which github-support branch to fetch support scripts from.
         required: false

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -318,7 +318,7 @@ jobs:
           name: build
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -495,7 +495,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -575,7 +575,7 @@ jobs:
           name: release
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -684,7 +684,7 @@ jobs:
           name: release-doc
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -318,7 +318,7 @@ jobs:
           name: build
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -495,7 +495,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
       - name: Cache dependencies
@@ -575,7 +575,7 @@ jobs:
           name: release
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 
@@ -684,7 +684,7 @@ jobs:
           name: release-doc
           version: ${{ inputs.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -38,7 +38,7 @@ on:
         type: string
         description: >
           Template parameter.
-          Path to Python file containing application version data. 
+          Path to Python file containing application version data.
       benchmark_make_workflow:
         required: true
         type: string
@@ -118,7 +118,7 @@ on:
           Note that the version in CentOS is locked by the Docker image.
         type: string
         required: false
-        default: "1.4"
+        default: "2.1.3"
     secrets:
       general-token:
         description: >
@@ -153,7 +153,7 @@ on:
         description: >
           Whether the release was successfully published to the website.
         value: ${{ jobs.update-website.outputs.publish-state == 'success' }}
-  
+
 jobs:
   bump-version:
     # skip if trying to re-run; PR is closed without merging; '[skip release]' is in the PR title; or if merging any branch other than pre_release_branch into release_branch

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -13,7 +13,7 @@ on:
         required: true
         type: string
       invocation_tests:
-        description: > 
+        description: >
           Run invocation tests.
         required: true
         type: string
@@ -104,7 +104,7 @@ on:
         required: false
         type: string
         description: Version of Poetry.
-        default: "1.4"
+        default: "2.1.3"
       install-timeout-minutes:
         required: false
         type: number
@@ -131,7 +131,7 @@ on:
         description: >
           PAT of user who has permission to bypass branch protection,
           or standard GITHUB_TOKEN if running on an external fork
-  
+
 # e.g. don't run simultaneously on the same branch (since we may commit to that branch)
 concurrency: ci-${{ inputs.head-ref && format('refs/heads/{0}', inputs.head-ref) || inputs.ref }}
 

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
@@ -282,7 +282,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
@@ -363,7 +363,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
@@ -468,7 +468,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
@@ -573,7 +573,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
@@ -282,7 +282,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
           version: ${{ inputs.poetry-version }}
@@ -363,7 +363,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
@@ -468,7 +468,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:
@@ -573,7 +573,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@main
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         id: poetry
         timeout-minutes: ${{ inputs.install-poetry-timeout-minutes }}
         with:

--- a/.github/workflows/test-pre-python-impl.yml
+++ b/.github/workflows/test-pre-python-impl.yml
@@ -27,8 +27,8 @@ on:
         required: false
         type: string
         description: Version of Poetry.
-        default: "1.4"
-  
+        default: "2.1.3"
+
 # Don't run simultaneously on the same branch (since we may commit to that branch)
 concurrency: ci-${{ inputs.head-ref && format('refs/heads/{0}', inputs.head-ref) || inputs.ref }}
 

--- a/.github/workflows/test-pre-python-impl.yml
+++ b/.github/workflows/test-pre-python-impl.yml
@@ -60,7 +60,7 @@ jobs:
           name: test
           version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@0.3
+        uses: hpcflow/github-support/setup-poetry@build/update-poetry
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/.github/workflows/test-pre-python-impl.yml
+++ b/.github/workflows/test-pre-python-impl.yml
@@ -60,7 +60,7 @@ jobs:
           name: test
           version: ${{ matrix.python-version }}
       - name: Set up poetry
-        uses: hpcflow/github-support/setup-poetry@build/update-poetry
+        uses: hpcflow/github-support/setup-poetry@main
         with:
           version: ${{ inputs.poetry-version }}
 

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -31,7 +31,6 @@ runs:
       shell: bash
       run: |
         poetry config virtualenvs.in-project true
-        poetry config installer.modern-installation false
         if [ "$RUNNER_OS" = "Windows" ]; then
           poetry config installer.max-workers 1
         fi


### PR DESCRIPTION
Will fix https://github.com/hpcflow/hpcflow-new/issues/788.

I have tested this in the `build/update-poetry` branch of `hpcflow-new`, which can be deleted once this PR is merged. Tests are here (I have checked these are using the desired Poetry version):

- benchmark: https://github.com/hpcflow/hpcflow-new/actions/runs/16317069343
- build-executables: https://github.com/hpcflow/hpcflow-new/actions/runs/16316913343
- test: https://github.com/hpcflow/hpcflow-new/actions/runs/16316789090

Unrelated failures:
- build-executables: https://github.com/hpcflow/hpcflow-new/issues/854
- test: https://github.com/hpcflow/hpcflow-new/issues/784

Note for these tests to work I had to temporarily change steps like:

```yaml
      - name: Set up poetry
        uses: hpcflow/github-support/setup-poetry@main
```
and
```yaml
      - name: Set up poetry
        uses: hpcflow/github-support/setup-poetry@0.3
```
to
```yaml
      - name: Set up poetry
        uses: hpcflow/github-support/setup-poetry@build/update-poetry
```
I <strike>will change</strike> have now changed these all to `@main` <strike>before this is PR is merged</strike>.

The version of Poetry in CentOS is fixed and is not affected by this PR, but is updated instead in https://github.com/hpcflow/github-support/pull/25.