### PR TITLE
fix: use more efficient app cache command

### DIFF
--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -201,8 +201,7 @@ jobs:
 
       - name: Cache all app data and programs
         run: |
-          poetry run ${{ inputs.executable_name }} data cache --all
-          poetry run ${{ inputs.executable_name }} program cache --all
+          poetry run ${{ inputs.executable_name }} manage cache-all
 
       - name: Upload all cached app data/programs
         id: upload-cached-app-data

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -321,8 +321,7 @@ jobs:
 
       - name: Cache all app data and programs
         run: |
-          poetry run ${{ inputs.executable_name }} data cache --all
-          poetry run ${{ inputs.executable_name }} program cache --all
+          poetry run ${{ inputs.executable_name }} manage cache-all
 
       - name: Upload all cached app data/programs
         id: upload-cached-app-data

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -212,8 +212,7 @@ jobs:
 
       - name: Cache all app data and programs
         run: |
-          poetry run python -m ${{ inputs.CLI_module }} data cache --all
-          poetry run python -m ${{ inputs.CLI_module }} program cache --all
+          poetry run python -m ${{ inputs.CLI_module }} manage cache-all
 
       - name: Upload all cached app data/programs
         id: upload-cached-app-data


### PR DESCRIPTION
Use changes in https://github.com/hpcflow/hpcflow/pull/940 to more efficiently cache app data in `test`, `build-exes` and `release` workflows.