### PR TITLE
fix: add skip condition to cache-app-data job in release workflow

### DIFF
--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -289,6 +289,8 @@ jobs:
           path: CHANGELOG_increment.md
 
   cache-app-data:
+    # skip if '[skip release]' is in the PR title; or if merging any branch other than pre_release_branch into release_branch
+    if: "!contains(inputs.pr-title, '[skip release]') && (inputs.pr-base-ref == inputs.pre_release_branch || (inputs.pr-base-ref == inputs.release_branch && inputs.pr-head-ref == inputs.pre_release_branch))"
     permissions:
       # No write permission
       contents: read


### PR DESCRIPTION
...since it does not depend on `bump-version`.