### PR TITLE
Don't put the app data cache in the benchmark data

### DIFF
--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.pr-head-ref }}
 
       - name: Set up python
         uses: actions/setup-python@v6
@@ -331,6 +331,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-app-data-cache
           path: ~/.cache/${{ inputs.executable_name }}
+          retention-days: 1
 
   build-executables:
     needs: [bump-version, cache-app-data]
@@ -464,6 +465,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [bump-version, cache-app-data]
     env:
+      BUILT_EXE_BASE_NAME: ${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}
       BUILT_EXE_PATH_DIR: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}-linux-dir/${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}-linux-dir
       BUILT_EXE_PATH_DIR_ZIPPED: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}-linux-dir.zip
       BUILT_EXE_PATH_FILE: ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.bump-version.outputs.new_tag }}-linux
@@ -597,8 +599,23 @@ jobs:
           path: benchmark_make_workflow_${{ matrix.num_elements }}_elements-${{ runner.os }}-py-${{ matrix.python-version }}.txt
           retention-days: 1
 
+  cleanup-cache:
+    needs:
+      - build-executables
+      - build-executables-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache artifact
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: "*-app-data-cache"
+          failOnError: false
+
+
   make-workflow-benchmark-upload:
-    needs: make-workflow-benchmark
+    needs:
+      - make-workflow-benchmark
+      - cleanup-cache
     runs-on: ubuntu-latest
     outputs:
       benchmark-url: ${{ steps.upload.outputs.artifact-url }}


### PR DESCRIPTION
The benchmark data ZIP file in releases had ballooned to nearly 900MB. This was due to including the cached executable builds, which really shouldn't have been there.