### PR TITLE
Reduce large data retention

### DIFF
--- a/.github/workflows/benchmark-impl.yml
+++ b/.github/workflows/benchmark-impl.yml
@@ -111,11 +111,16 @@ jobs:
       - name: Make directory
         run: |
           mkdir benchmarks
-      - name: Fetch benchmark files
+      - name: Fetch benchmark data
         uses: actions/download-artifact@v8
         with:
           merge-multiple: true
           path: benchmarks
+      - name: Delete partial benchmark data
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: "*"
+          failOnError: false
       - name: Store benchmark data archive
         uses: actions/upload-artifact@v7
         id: upload

--- a/.github/workflows/build-exes-impl.yml
+++ b/.github/workflows/build-exes-impl.yml
@@ -159,6 +159,7 @@ jobs:
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
   cache-app-data:
+    needs: status
     permissions:
       # No write permission
       contents: read
@@ -167,7 +168,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ needs.status.outputs.sha }}
 
       - name: Set up python
         uses: actions/setup-python@v6
@@ -209,6 +210,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-app-data-cache
           path: ~/.cache/${{ inputs.executable_name }}
+          retention-days: 1
 
   windows:
     name: Build Windows Executables
@@ -279,6 +281,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win.exe
           path: ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win.exe
+          retention-days: 7
 
       - name: Upload executable artifact (folder)
         id: upload-folder
@@ -287,6 +290,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win-dir
           path: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win-dir
+          retention-days: 7
 
       - name: Upload spec file
         if: steps.win_onefile.outcome == 'success' || steps.win_onedir.outcome == 'success'
@@ -294,6 +298,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win.spec
           path: ${{ inputs.pyinstaller_dir }}/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win.spec
+          retention-days: 7
 
       - name: Upload build directory
         if: steps.win_onefile.outcome == 'success' || steps.win_onedir.outcome == 'success'
@@ -301,6 +306,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win-build
           path: ${{ inputs.pyinstaller_dir }}/build/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-win
+          retention-days: 3
 
       - name: Install cached app data
         env:
@@ -407,6 +413,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS
           path: ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS
+          retention-days: 7
 
       - name: Upload executable artifact (folder)
         id: upload-folder
@@ -415,6 +422,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir
           path: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-dir
+          retention-days: 7
 
       - name: Upload spec file
         if: steps.mac_onefile.outcome == 'success' || steps.mac_onedir.outcome == 'success'
@@ -422,6 +430,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS.spec
           path: ${{ inputs.pyinstaller_dir }}/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS.spec
+          retention-days: 7
 
       - name: Upload build directory
         if: steps.mac_onefile.outcome == 'success' || steps.mac_onedir.outcome == 'success'
@@ -429,6 +438,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS-build
           path: ${{ inputs.pyinstaller_dir }}/build/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-macOS
+          retention-days: 3
 
       - name: Install cached app data
         run: |
@@ -493,9 +503,9 @@ jobs:
           path: ${{ inputs.executable_name }}-app-data-cache
 
       - name: Store user and group IDs
+        id: user
         run: |
-          echo "UID=$(id -u)" >> $GITHUB_ENV
-          echo "GID=$(id -g)" >> $GITHUB_ENV
+          echo "user=$(id -u):$(id -g)" >> $GITHUB_OUTPUT
 
       - name: Build executable (file) within Docker
         id: linux_onefile
@@ -505,7 +515,7 @@ jobs:
           image: ghcr.io/hpcflow/rockylinux8-python:latest # most of the options are just so we can debug (via tmate) when we have a custom pytest --basetemp directory
           options: |
             -v ${{ github.workspace }}:/home
-            -u ${{ env.UID }}:${{ env.GID }}
+            -u ${{ steps.user.outputs.user }}
             --env HOME=/home
             --env XDG_DATA_HOME=/home/.local/share
             --env XDG_CACHE_HOME=/home/.cache
@@ -555,7 +565,9 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ghcr.io/hpcflow/rockylinux8-python:latest
-          options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          options: |
+            -v ${{ github.workspace }}:/home
+            --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             set -e # exit on first failure
 
@@ -594,6 +606,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux
           path: ${{ inputs.pyinstaller_dir }}/dist/onefile/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux
+          retention-days: 7
 
       - name: Upload executable artifact (folder)
         id: upload-folder
@@ -602,6 +615,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir
           path: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-dir
+          retention-days: 7
 
       - name: Upload spec file
         if: steps.linux_onefile.outcome == 'success' || steps.linux_onedir.outcome == 'success'
@@ -609,6 +623,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux.spec
           path: ${{ inputs.pyinstaller_dir }}/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux.spec
+          retention-days: 7
 
       - name: Upload build directory
         if: steps.linux_onefile.outcome == 'success' || steps.linux_onedir.outcome == 'success'
@@ -616,3 +631,17 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux-build
           path: ${{ inputs.pyinstaller_dir }}/build/${{ inputs.executable_name }}-${{ needs.status.outputs.version }}-linux
+          retention-days: 3
+
+  cleanup-cache:
+    needs:
+      - linux
+      - macos
+      - windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache artifact
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: "*-app-data-cache"
+          failOnError: false

--- a/.github/workflows/doc-build-impl.yml
+++ b/.github/workflows/doc-build-impl.yml
@@ -125,6 +125,7 @@ jobs:
           name: ${{ inputs.artifact-root-name }}-documentation (${{ inputs.ref }})
           path: docs/build/html
           if-no-files-found: error
+          retention-days: ${{ inputs.deploy && 1 || 7 }}
 
   deploy:
     # New style doc uploader

--- a/.github/workflows/release-impl.yml
+++ b/.github/workflows/release-impl.yml
@@ -454,12 +454,14 @@ jobs:
         with:
           name: ${{ env.BUILT_EXE_BASE_NAME }}-${{ matrix.executable_os }}${{ matrix.executable_ext }}
           path: ${{ env.BUILT_EXE_PATH_FILE }}
+          retention-days: 7
 
       - name: Upload executable artifact (compressed folder)
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILT_EXE_BASE_NAME }}-${{ matrix.executable_os }}-dir.zip
           path: ${{ env.BUILT_EXE_PATH_DIR_ZIPPED }}
+          retention-days: 7
 
   build-executables-linux:
     runs-on: ubuntu-latest
@@ -490,7 +492,9 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ghcr.io/hpcflow/rockylinux8-python:latest
-          options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.general-token }}
+          options: |
+            -v ${{ github.workspace }}:/home
+            --env GH_TOKEN=${{ secrets.general-token }}
           run: |
             # set up poetry
             cd /home
@@ -542,12 +546,14 @@ jobs:
         with:
           name: ${{ env.BUILT_EXE_BASE_NAME }}-linux
           path: ${{ env.BUILT_EXE_PATH_FILE }}
+          retention-days: 7
 
       - name: Upload executable artifact (compressed folder)
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BUILT_EXE_BASE_NAME }}-linux-dir.zip
           path: ${{ inputs.pyinstaller_dir }}/dist/onedir/${{ env.BUILT_EXE_BASE_NAME }}-linux-dir.zip
+          retention-days: 7
 
   make-workflow-benchmark:
     needs: bump-version
@@ -610,7 +616,6 @@ jobs:
         with:
           name: "*-app-data-cache"
           failOnError: false
-
 
   make-workflow-benchmark-upload:
     needs:

--- a/.github/workflows/test-impl.yml
+++ b/.github/workflows/test-impl.yml
@@ -220,6 +220,7 @@ jobs:
         with:
           name: ${{ inputs.executable_name }}-app-data-cache
           path: ~/.cache/${{ inputs.executable_name }}
+          retention-days: 1
 
   test-units:
     needs: [pre-commit, cache-app-data]
@@ -313,7 +314,9 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ghcr.io/hpcflow/rockylinux8-python:latest
-          options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          options: |
+            -v ${{ github.workspace }}:/home
+            --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             cd /home
             poetry config virtualenvs.in-project true
@@ -417,7 +420,9 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: ghcr.io/hpcflow/rockylinux8-python:latest
-          options: -v ${{ github.workspace }}:/home --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          options: |
+            -v ${{ github.workspace }}:/home
+            --env GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
           run: |
             cd /home
             poetry config virtualenvs.in-project true
@@ -732,3 +737,17 @@ jobs:
           ."${{ steps.poetry.outputs.poetry-path }}\Scripts\activate.ps1"
           python -m ipykernel install --user --name python3
           papermill github-support\scripts\test_direct_sub_jupyter_notebook.ipynb papermill_out\test_direct_sub_jupyter_notebook_${{ matrix.python-version }}_${{ runner.os }}.ipynb -p app_import_str ${{ inputs.app_package }}
+
+  cleanup-cache:
+    needs:
+      - test-units
+      - test-units-RockyLinux
+      - test-integration
+      - test-integration-RockyLinux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete cache artifact
+        uses: geekyeggo/delete-artifact@v6
+        with:
+          name: "*-app-data-cache"
+          failOnError: false


### PR DESCRIPTION
Reduce the amount that intermediate cache data is retained, and also that of the larger build products. The typical rule is:
* keep intermediates 1 day
* keep large products 3 to 7 days
* keep small products (up to a few MB) up to the system default.
 
Keeping large intermediates around a long time (1 month or more) causes problems for other parts of the university. We _can't_ allow that to continue.

----

I've also fixed a few minor typos elsewhere in these workflows.